### PR TITLE
Add the packing step back.

### DIFF
--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -98,5 +98,4 @@ jobs:
 
       - name: Deploy
         run: |
-          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
-          dotnet nuget push ${{github.workspace}}/artifacts/*.nupkg --skip-duplicate --source authed-nuget
+          dotnet nuget push ${{github.workspace}}/artifacts/*.nupkg --skip-duplicate --source https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_AUTH_TOKEN}}

--- a/.github/workflows/deploy-pack.yml
+++ b/.github/workflows/deploy-pack.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
+      - name: Build (Framework)
+        run: dotnet build -c Release osu.Framework.Microphone /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true///
+
       - name: Pack (Framework)
         run: dotnet pack -c Release osu.Framework.Microphone /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 

--- a/osu.Framework.Microphone/osu.Framework.Microphone.csproj
+++ b/osu.Framework.Microphone/osu.Framework.Microphone.csproj
@@ -8,7 +8,6 @@
     <GenerateProgramFile>false</GenerateProgramFile>
     <AssemblyName>osu.Framework.Microphone</AssemblyName>
     <RootNamespace>osu.Framework</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IsPackable>true</IsPackable>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Version>1.2.0</Version>


### PR DESCRIPTION
Fix the deploy to nuget broken.

Here's the log:
```
51s
Run dotnet pack -c Release osu.Framework.Microphone /p:Version=2022.[1](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:1)22[6](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:7).0 /p:GenerateDocumentationFile=true  -o D:\a\osu-framework-microphone\osu-framework-microphone\artifacts

Welcome to .NET 6.0!
---------------------
SDK Version: 6.0.404

Telemetry
---------
The .NET tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_CLI_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.

Read more about .NET CLI Tools telemetry: https://aka.ms/dotnet-cli-telemetry

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
Learn about HTTPS: https://aka.ms/dotnet-https
----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
MSBuild version 1[7](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:8).3.2+561[8](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:9)48881 for .NET
  Determining projects to restore...
  Restored D:\a\osu-framework-microphone\osu-framework-microphone\osu.Framework.Microphone\osu.Framework.Microphone.csproj (in 46.55 sec).
Error: C:\Users\runneradmin\AppData\Local\Microsoft\dotnet\sdk\6.0.404\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(2[21](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:22),5): error NU50[26](https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:27): The file 'D:\a\osu-framework-microphone\osu-framework-microphone\osu.Framework.Microphone\bin\Release\net6.0\osu.Framework.Microphone.dll' to be packed was not found on disk. [D:\a\osu-framework-microphone\osu-framework-microphone\osu.Framework.Microphone\osu.Framework.Microphone.csproj]
```

Guess it's because `dotnet build` has been removed in the #284

Here's the action:
https://github.com/karaoke-dev/osu-framework-microphone/actions/runs/3781748083/jobs/6428896491#step:6:221